### PR TITLE
rubocop-rails -> rubocop-rails_config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_gem:
-  rubocop-rails:
+  rubocop-rails_config:
     - config/rails.yml

--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 group :development do
   gem "bullet"
   gem "listen"
-  gem "rubocop-rails"
+  gem "rubocop-rails_config"
   gem "spring"
   gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -120,7 +121,7 @@ GEM
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -183,14 +184,15 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.56.0)
+    rubocop (0.57.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rails (1.4.1)
+    rubocop-rails_config (0.1.0)
       railties (>= 3.0)
       rubocop (~> 0.53)
     ruby-progressbar (1.9.0)
@@ -235,7 +237,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.12)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.3.2)
+    unicode-display_width (1.4.0)
     uniform_notifier (1.11.0)
     web-console (3.6.2)
       actionview (>= 5.0)
@@ -274,7 +276,7 @@ DEPENDENCIES
   rails (~> 5.1.6)
   rails-controller-testing
   rspec-rails
-  rubocop-rails
+  rubocop-rails_config
   sass-rails (~> 5.0)
   simplecov
   slim

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,4 @@
+linter:
+  rubocop:
+    gems:
+      - rubocop-rails_config


### PR DESCRIPTION
rubocop-rails is going to be renamed to rubocop-rails_config. (ref. https://github.com/toshimaru/rubocop-rails/issues/31)

In this PR, Update `rubocop-rails` to `rubocop-rails_config`.
