### PR TITLE
Re-try System Spec

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :selenium, using: :headless_chrome
+    driven_by :headless_chrome
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :headless_chrome
+    driven_by :selenium, using: :headless_chrome
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,6 +81,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
+    driven_by :headless_chrome
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,4 +75,12 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,7 +14,9 @@ SimpleCov.start "rails"
 require "rspec/rails"
 
 # Add additional requires below this line. Rails is not loaded until this point!
-require "selenium-webdriver"
+
+# Specifying `no-sandbox` is required, so use custom driver instead of `selenium_chrome_headless`.
+# ref. https://github.com/teamcapybara/capybara/blob/c7c22789b7aaf6c1515bf6e68f00bfe074cf8fc1/lib/capybara/registrations/drivers.rb#L27-L36
 Capybara.register_driver :headless_chrome do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.args << "--headless"
@@ -23,10 +25,6 @@ Capybara.register_driver :headless_chrome do |app|
   end
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
-Capybara.javascript_driver = :headless_chrome
-# Specifying `no-sandbox` is required, so use custom driver instead of `selenium_chrome_headless`.
-# ref. https://github.com/teamcapybara/capybara/blob/c7c22789b7aaf6c1515bf6e68f00bfe074cf8fc1/lib/capybara/registrations/drivers.rb#L27-L36
-# Capybara.javascript_driver = :selenium_chrome_headless
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/system/authentication_pages_spec.rb
+++ b/spec/system/authentication_pages_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Authentication", type: :feature do
+RSpec.describe "Authentication", type: :system do
   subject { page }
 
   describe "authorization" do

--- a/spec/system/static_pages_spec.rb
+++ b/spec/system/static_pages_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Static Pages", type: :feature do
+RSpec.describe "Static Pages", type: :system do
   subject { page }
 
   describe "Home Page" do

--- a/spec/system/tweet_pages_spec.rb
+++ b/spec/system/tweet_pages_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Tweet pages", type: :feature do
+RSpec.describe "Tweet pages", type: :system do
   subject { page }
 
   let(:user) { FactoryBot.create(:user) }

--- a/spec/system/user_pages_spec.rb
+++ b/spec/system/user_pages_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "UserPages", type: :feature do
+RSpec.describe "UserPages", type: :system do
   subject { page }
 
   let(:user) { FactoryBot.create(:user) }


### PR DESCRIPTION
## Description

Re-try System Spec (first try: #216)


## Reference

- [Testing Rails Applications — Ruby on Rails Guides](https://guides.rubyonrails.org/testing.html#system-testing)
- [ruby on rails - Capybara headless chrome in docker returns DevToolsActivePort file doesn't exist - Stack Overflow](https://stackoverflow.com/questions/50610316/capybara-headless-chrome-in-docker-returns-devtoolsactiveport-file-doesnt-exist/50612056#50612056)