### PR TITLE
Add rails db:populate Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ before_install:
   - ./cc-test-reporter before-build
 rvm:
   - 2.6.4
+script:
+  - bundle exec rake
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 rvm:
   - 2.6.4
 script:
-  - bundle exec rake
+  - bundle exec rails db:migrate
+  - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ rvm:
   - 2.6.4
 script:
   - bundle exec rails db:migrate
+  - bundle exec rails db:populate
   - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ gem "will_paginate"
 # gem 'mini_magick', '~> 4.8'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Test Coverage](https://codeclimate.com/github/toshimaru/RailsTwitterClone/badges/coverage.svg)](https://codeclimate.com/github/toshimaru/RailsTwitterClone/coverage)
 [![CircleCI](https://circleci.com/gh/toshimaru/RailsTwitterClone.svg?style=svg)](https://circleci.com/gh/toshimaru/RailsTwitterClone)
 
-![Github Clone Screen Capture](https://cloud.githubusercontent.com/assets/803398/5903211/acdfe32c-a5c3-11e4-8171-b5ab2c3ef806.png)
+![Twitter Clone Screen Capture](https://cloud.githubusercontent.com/assets/803398/5903211/acdfe32c-a5c3-11e4-8171-b5ab2c3ef806.png)
 
 ## Implementation
 
@@ -26,9 +26,9 @@ $ bundle exec rails server
 
 This application doesn't provide many features in order to keep it simple. Here are the features that it does include:
 
-* See timeline
-* Post new tweet
-* Follow/Unfollow user
+* See TimeLine
+* Post new Tweet
+* Follow/Unfollow User
 
 ## Used gem
 

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -33,7 +33,7 @@ end
 def make_tweets
   users = User.all
   50.times do
-    content = Faker::Lorem.sentence(5)
+    content = Faker::Lorem.sentence(word_count: 5)
     users.each { |user| user.tweets.create!(content: content) }
   end
 end


### PR DESCRIPTION
Add test for `db:populate` and `db:migrate` on TravisCI.

```
rails db:populate                        # Fill database with sample data
```

Fix faker deprecation warning:

```
Passing `word_count` with the 1st argument of `sentence` is deprecated. Use keyword argument like `sentence(word_count: ...)` instead.
```

