### PR TITLE
[GitHub Actions]runs-on: ubuntu-latest -> ubuntu-16

### DIFF
--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -2,7 +2,7 @@ name: Docker Compose Build
 on: [push]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v1
     - name: Build & Test

--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -1,11 +1,10 @@
-name: Docker Compose Build
+name: Docker Compose
 on: [push]
 jobs:
   build:
     runs-on: ubuntu-16.04
+    name: Build & Test
     steps:
     - uses: actions/checkout@v1
-    - name: Build & Test
-      run: |
-        docker-compose build
-        docker-compose run web rspec
+    - run: docker-compose build
+    - run: docker-compose run web rspec


### PR DESCRIPTION
Runbing test on ubuntu-latest causes CI error, so downgrade ubuntu to 16.

I'd like to use `ubuntu-latest`, so this change would be a temporary change.