### PR TITLE
Update macos.yml and Use bundler v2.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
     executor: default
     steps:
       - checkout
+      - run: gem install bundler
       - bundle-install/bundle-install
   rspec:
     executor: default
@@ -38,6 +39,7 @@ jobs:
     executor: default
     steps:
       - checkout
+      - run: gem install bundler
       - bundle-install/bundle-install
       - run: bundle exec rubocop
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
     executor: default
     steps:
       - checkout
+      - run: gem install bundler
       - bundle-install/bundle-install
       - run: bundle exec rails db:create db:schema:load
       - run:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,6 +25,7 @@ jobs:
           ${{ runner.os }}-bundler-
     - name: bundle install
       run: |
+        gem install bundler
         bundle install --jobs 4 --retry 3 --path vendor/bundle
     - name: Run RSpec
       run: bundle exec rake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
+        restore-keys: |
+          ${{ runner.os }}-bundler-
     - name: bundle install
       run: |
         bundle update --bundler

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,9 @@ jobs:
         brew update
         brew cask install google-chrome chromedriver
     - uses: actions/cache@v1
-      id: cache
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-${{ hashFiles('**/Gemfile.lock')}}
+        key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
     - name: bundle install
       run: |
         bundle update --bundler

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,9 +20,9 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
+        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
         restore-keys: |
-          ${{ runner.os }}-bundler-
+          ${{ runner.os }}-${{ matrix.ruby }}-bundler-
     - name: bundle install
       run: |
         gem install bundler

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,9 +17,14 @@ jobs:
       run: |
         brew update
         brew cask install google-chrome chromedriver
+    - uses: actions/cache@v1
+      id: cache
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-${{ hashFiles('**/Gemfile.lock')}}
     - name: bundle install
       run: |
         bundle update --bundler
-        bundle install --jobs 4 --retry 3
+        bundle install --jobs 4 --retry 3 --path vendor/bundle
     - name: Run RSpec
       run: bundle exec rake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,6 @@ jobs:
           ${{ runner.os }}-bundler-
     - name: bundle install
       run: |
-        bundle update --bundler
         bundle install --jobs 4 --retry 3 --path vendor/bundle
     - name: Run RSpec
       run: bundle exec rake

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,10 +17,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libsqlite3-dev chromium-driver
+    - uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
+        restore-keys: |
+          ${{ runner.os }}-bundler-
     - name: bundle install
       run: |
         gem install bundler
-        bundle update --bundler
-        bundle install --jobs 4 --retry 3
+        bundle install --jobs 4 --retry 3 --path vendor/bundle
     - name: Run RSpec
       run: bundle exec rake

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -20,9 +20,9 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
+        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
         restore-keys: |
-          ${{ runner.os }}-bundler-
+          ${{ runner.os }}-${{ matrix.ruby }}-bundler-
     - name: bundle install
       run: |
         gem install bundler

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN apt-get update -qq && apt-get install -y nodejs chromium-driver && apt-get c
 RUN mkdir /app
 COPY Gemfile Gemfile.lock /app/
 WORKDIR /app
+RUN gem install bundler
 RUN bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,4 +302,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.17.3
+   2.0.2


### PR DESCRIPTION
## Before

4mins on Ubuntu.

## After

10secs on Ubuntu.

## References

- [Caching dependencies to speed up workflows - GitHub Help](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows)
- [actions/cache: Cache dependencies and build outputs in GitHub Actions](https://github.com/actions/cache)