### PR TITLE
Add Ruby 2.7 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   default:
     working_directory: ~/app
     docker:
-      - image: circleci/ruby:2.6-node-browsers
+      - image: circleci/ruby:2.7-node-browsers
         environment:
           RAILS_ENV: test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  bundle-install: toshimaru/bundle-install@0.3.0
+  bundle-install: toshimaru/bundle-install@0.3.1
 
 executors:
   default:

--- a/.github/workflows/docker-compose-build.yml
+++ b/.github/workflows/docker-compose-build.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-16.04
     name: Build & Test
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: docker-compose build
     - run: docker-compose run web bundle exec rspec

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7]
     runs-on: macos-latest
     name: RSpec
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.6.x]
+        ruby: [2.5.x, 2.6.x]
     runs-on: macos-latest
     name: RSpec
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,13 +4,13 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.5.x, 2.6.x]
+        ruby: [2.5, 2.6, 2.7]
     runs-on: macos-latest
     name: RSpec
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: eregon/use-ruby-action@master
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Dependencies

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     name: RuboCop
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.6
     - name: Install rubocop
       run: |
         gem install bundled_gems

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,13 +4,13 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
+        ruby: [2.4, 2.5, 2.6, 2.7]
     runs-on: ubuntu-latest
     name: RSpec
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: eregon/use-ruby-action@master
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Dependencies

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4.x, 2.5.x, 2.6.x]
+        ruby: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
     runs-on: ubuntu-latest
     name: RSpec
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 RUN apt-get update -qq && apt-get install -y nodejs chromium-driver && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN mkdir /app


### PR DESCRIPTION
- Use [eregon/use-ruby-action](https://github.com/eregon/use-ruby-action) instead of `actions/setup-ruby`
  - since official [actions/setup-ruby](https://github.com/actions/setup-ruby) doesn't support Ruby 2.7 yet.