### PR TITLE
Drop Ruby 2.4

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
     runs-on: macos-latest
     name: RSpec
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.5, 2.6, 2.7]
     runs-on: ubuntu-latest
     name: RSpec
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,4 @@ inherit_gem:
     - config/rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5


### PR DESCRIPTION
- Drop Ruby 2.4 for the preparation of Rails 6.