### PR TITLE
Optimize docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 node_modules/
+vendor/bundle/

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@
 /.bundle
 
 # Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
+/db/**/*.sqlite3
+/db/**/*.sqlite3-journal
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 development:
   adapter: sqlite3
-  database: db/development.sqlite3
+  database: db/sqlite/development.sqlite3
   pool: 5
   timeout: 5000
 
@@ -14,12 +14,12 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: db/test.sqlite3
+  database: db/sqlite/test.sqlite3
   pool: 5
   timeout: 5000
 
 production:
   adapter: sqlite3
-  database: db/production.sqlite3
+  database: db/sqlite/production.sqlite3
   pool: 5
   timeout: 5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && rails s -b '0.0.0.0'"
     volumes:
       - .:/app:cached
+      - /app/.git
+      - /app/log
       - /app/node_modules
+      - /app/tmp
+      - /app/vendor
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && rails s -b '0.0.0.0'"
     volumes:
-      - .:/app
+      - .:/app:cached
       - /app/node_modules
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
       - /app/node_modules
       - /app/tmp
       - /app/vendor
+      - /app/db/sqlite
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Reference

- [docker-composeを爆速にする - Qiita](https://qiita.com/shotat/items/57d049793605ffc20135)

## Before

```
docker-compose run web bundle exec rspec  0.61s user 0.18s system 1% cpu 1:01.00 total
docker-compose run web bundle exec rspec  0.68s user 0.22s system 1% cpu 59.618 total
docker-compose run web bundle exec rspec  0.62s user 0.17s system 1% cpu 1:03.93 total
```

## After

```
docker-compose run web bundle exec rspec  0.62s user 0.15s system 1% cpu 44.627 total
docker-compose run web bundle exec rspec  0.70s user 0.24s system 1% cpu 47.684 total
docker-compose run web bundle exec rspec  0.64s user 0.19s system 1% cpu 45.349 total
```

## Result

**rspec gets 20% faster**.