### PR TITLE
Exclude Headless Chrome (JavaScript) tests on TravisCI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,8 +28,4 @@ jobs:
         gem install bundler
         bundle install --jobs 4 --retry 3 --path vendor/bundle
     - name: Run RSpec
-      # FIXME:
-      # macOS CI error: raise Error::WebDriverError, cannot_connect_error_text
-      # Selenium::WebDriver::Error::WebDriverError:
-      #   unable to connect to chromedriver 127.0.0.1:9515
-      run: bundle exec rspec --tag ~js:true
+      run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ script:
   - bundle exec rails db:migrate
   - bundle exec rails db:populate
   - bundle exec rails db:reset
-  - bundle exec rspec
+  - bundle exec rspec --tag ~js:true
 after_failure:
   - cat log/test.log


### PR DESCRIPTION
Since it causes CI error.