### PR TITLE
Use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -1,9 +1,9 @@
 name: 'Auto Author Assign'
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 jobs:
-  add-assignees:
+  add-assignee:
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v1.1.2


### PR DESCRIPTION
> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload.

ref. https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/