### PR TITLE
GitHub Actions update: Trigger rspec & coverage workflow on pull_request

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 name: Coverage
-on: [push]
+on: [push, pull_request]
 jobs:
   coverage:
     name: CodeClimate

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,5 +1,5 @@
 name: RSpec
-on: [push]
+on: [push, pull_request]
 jobs:
   ubuntu-build:
     strategy:


### PR DESCRIPTION
The workflow doesn't run when the PR comes from forked repository.

So, added `on: pull_request` in addition to `on: push`