### PR TITLE
Migrate CircleCI image from circleci/ruby to cimg/ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - ruby/install-deps
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
-      - run: bundle exec rails db:create db:schema:load
+      - run: bin/rails db:schema:load --trace
       - ruby/rspec-test
       - store_artifacts:
           path: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   ruby: circleci/ruby@1.1.2
-  browser-tools: circleci/browser-tools@1.1.0
+  browser-tools: circleci/browser-tools@1.1.3
 
 executors:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   default:
     working_directory: ~/app
     docker:
-      - image: circleci/ruby:2.7-node-browsers
+      - image: cimg/ruby:2.7-browsers
         environment:
           RAILS_ENV: test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run: sudo apt-get install libsqlite3-dev
+      - run: |
+        sudo apt update
+        sudo apt install libsqlite3-dev
       - ruby/install-deps
   rspec:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,11 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run: |
-        sudo apt update
-        sudo apt install libsqlite3-dev
+      - run:
+          name: Install System Dependencies
+          command: |
+            sudo apt update
+            sudo apt install libsqlite3-dev
       - ruby/install-deps
   rspec:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run: gem install bundler
+      - run: brew install sqlite3
       - ruby/install-deps
   rspec:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  bundle-install: toshimaru/bundle-install@0.3.1
+  ruby: circleci/ruby@1.1.2
 
 executors:
   default:
@@ -17,13 +17,13 @@ jobs:
     steps:
       - checkout
       - run: gem install bundler
-      - bundle-install/bundle-install
+      - ruby/install-deps
   rspec:
     executor: default
     steps:
       - checkout
       - run: gem install bundler
-      - bundle-install/bundle-install
+      - ruby/install-deps
       - run: bundle exec rails db:create db:schema:load
       - run:
           name: Run RSpec
@@ -40,7 +40,7 @@ jobs:
     steps:
       - checkout
       - run: gem install bundler
-      - bundle-install/bundle-install
+      - ruby/install-deps
       - run: bundle exec rubocop
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: ruby/default
+      - image: cimg/ruby:2.7-browsers
         environment:
           RAILS_ENV: test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,16 +31,11 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run: bundle exec rails db:create db:schema:load
-      - run:
-          name: Run RSpec
-          command: |
-            bundle exec rspec --format progress --format RspecJunitFormatter -o ~/test-results/rspec/rspec.xml
+      - ruby/rspec-test
       - store_artifacts:
           path: coverage
       - store_artifacts:
           path: tmp/capybara
-      - store_test_results:
-          path: ~/test-results/rspec/
   rubocop:
     executor: default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   ruby: circleci/ruby@1.1.2
+  browser-tools: circleci/browser-tools@1.1.0
 
 executors:
   default:
@@ -26,8 +27,8 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run: gem install bundler
       - ruby/install-deps
+      - browser-tools/install-chromedriver
       - run: bundle exec rails db:create db:schema:load
       - run:
           name: Run RSpec
@@ -43,7 +44,6 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run: gem install bundler
       - ruby/install-deps
       - run: bundle exec rubocop
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - run: bundle exec rubocop
+      - ruby/rubocop-check
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,14 @@ jobs:
           command: |
             sudo apt update
             sudo apt install libsqlite3-dev
-      - ruby/install-deps
+      - ruby/install-deps:
+          key: gems-v2
   rspec:
     executor: default
     steps:
       - checkout
-      - ruby/install-deps
+      - ruby/install-deps:
+          key: gems-v2
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run: bin/rails db:schema:load --trace
@@ -39,7 +41,8 @@ jobs:
     executor: default
     steps:
       - checkout
-      - ruby/install-deps
+      - ruby/install-deps:
+          key: gems-v2
       - ruby/rubocop-check
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,8 @@ orbs:
 
 executors:
   default:
-    working_directory: ~/app
     docker:
-      - image: cimg/ruby:2.7-browsers
+      - image: ruby/default
         environment:
           RAILS_ENV: test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
+      - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run: bundle exec rails db:create db:schema:load
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run: brew install sqlite3
+      - run: sudo apt-get install libsqlite3-dev
       - ruby/install-deps
   rspec:
     executor: default


### PR DESCRIPTION
## reference

- Orbs
  - [CircleCI Developer Hub - circleci/ruby](https://circleci.com/developer/orbs/orb/circleci/ruby)
  - [CircleCI Developer Hub - circleci/browser-tools](https://circleci.com/developer/orbs/orb/circleci/browser-tools)
- cimg/ruby
  - [CircleCI Developer - Convenience Images](https://circleci.com/developer/images/image/cimg/ruby)
- [circleci-demo-ruby-rails/config.yml at master · CircleCI-Public/circleci-demo-ruby-rails](https://github.com/CircleCI-Public/circleci-demo-ruby-rails/blob/master/.circleci/config.yml)
- Japanese Blog
  - [CircleCI config.yml ひな型 Rails 6 / PostgreSQL / Rspec（orbと最新のimageの利用） - Qiita](https://qiita.com/kazutosato/items/3f08a4da350a395f3bd2)
  - [[Go]次世代イメージcimg/goとcircleci/go Orbsを使った2020年版CircleCIの環境構築 - My External Storage](https://budougumi0617.github.io/2020/06/08/circleci_cimg_go_2020/)