### PR TITLE
Use ruby/setup-ruby instead of actions/setup-ruby

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Install Dependencies

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install Dependencies
@@ -40,7 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - uses: actions/cache@v2

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
     - name: Install rubocop
@@ -29,7 +29,7 @@ jobs:
           reviewdog_version: latest
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
       - name: Install rubocop


### PR DESCRIPTION
## Refs

- https://github.com/actions/starter-workflows/blob/main/ci/ruby.yml
   - https://github.com/actions/starter-workflows/blob/e9e00b017736d3b3811cedf1ee2e8ceb3c48e3dd/ci/ruby.yml#L24-L29
- [GitHub Actionsでrubyを使うなら ruby/setup-ruby を使おう - masa寿司の日記](https://mstshiwasaki.hatenablog.com/entry/2020/02/08/130844)