### PR TITLE
Update github actions configuration

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -6,6 +6,6 @@ jobs:
   assign-author:
     runs-on: ubuntu-latest
     steps:
-      - uses: toshimaru/auto-author-assign@v1.1.2
+      - uses: toshimaru/auto-author-assign@v1.2.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,6 @@ jobs:
   coverage:
     name: CodeClimate
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby 2.6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,21 +10,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get remove google-chrome-stable
-        sudo apt-get install libsqlite3-dev chromium-driver
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
-        restore-keys: ${{ runner.os }}-${{ matrix.ruby }}-bundler-
-    - name: bundle install
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - uses: paambaati/codeclimate-action@v2.6.0
       env:
         CC_TEST_REPORTER_ID: a74e9933c8093d8a99be5c3ba44b7a82554eec9505f4674356f305e4667144b1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
-    - uses: paambaati/codeclimate-action@v2.6.0
+    - uses: paambaati/codeclimate-action@v2.7.5
       env:
         CC_TEST_REPORTER_ID: a74e9933c8093d8a99be5c3ba44b7a82554eec9505f4674356f305e4667144b1
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
     - name: Install Dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -13,11 +13,11 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get remove google-chrome-stable
-        sudo apt-get install libsqlite3-dev chromium-driver
+    # - name: Install Dependencies
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get remove google-chrome-stable
+    #     sudo apt-get install libsqlite3-dev chromium-driver
     - name: Run RSpec
       run: bundle exec rspec
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,7 +6,6 @@ jobs:
       matrix:
         ruby: [2.5, 2.6, 2.7]
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
@@ -36,7 +35,6 @@ jobs:
       matrix:
         ruby: [2.5, 2.6, 2.7]
     runs-on: macos-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
@@ -58,7 +56,6 @@ jobs:
 
   docker-compose-build:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
     - uses: actions/checkout@v2
     - run: docker-compose build

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,21 +12,12 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Install Dependencies
       run: |
         sudo apt-get update
         sudo apt-get remove google-chrome-stable
         sudo apt-get install libsqlite3-dev chromium-driver
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-v1-${{ hashFiles('**/Gemfile.lock')}}
-        restore-keys: ${{ runner.os }}-${{ matrix.ruby }}-bundler-v1-
-    - name: bundle install
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
     - name: Run RSpec
       run: bundle exec rspec
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,8 +20,8 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
-        restore-keys: ${{ runner.os }}-${{ matrix.ruby }}-bundler-
+        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-v1-${{ hashFiles('**/Gemfile.lock')}}
+        restore-keys: ${{ runner.os }}-${{ matrix.ruby }}-bundler-v1-
     - name: bundle install
       run: |
         gem install bundler

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,11 +1,12 @@
 name: RSpec
 on: [push, pull_request]
 jobs:
-  ubuntu-build:
+  build:
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest]
         ruby: [2.5, 2.6, 2.7]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
@@ -13,38 +14,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    # - name: Install Dependencies
-    #   run: |
-    #     sudo apt-get update
-    #     sudo apt-get remove google-chrome-stable
-    #     sudo apt-get install libsqlite3-dev chromium-driver
     - name: Run RSpec
       run: bundle exec rspec
-
-  macos-build:
-    strategy:
-      matrix:
-        ruby: [2.5, 2.6, 2.7]
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-${{ matrix.ruby }}-bundler-${{ hashFiles('**/Gemfile.lock')}}
-        restore-keys: ${{ runner.os }}-${{ matrix.ruby }}-bundler-
-    - name: bundle install
-      run: |
-        gem install bundler
-        bundle config set path 'vendor/bundle'
-        bundle install --jobs 4 --retry 3
-    - name: Run RSpec
-      run: bundle exec rspec
-
   docker-compose-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,7 +11,7 @@ jobs:
         ruby-version: 2.7
         bundler-cache: true
     - name: Run RuboCop
-      run: rubocop --parallel -f progress -f html -o tmp/rubocop/report.html
+      run: bundle exec rubocop --parallel -f progress -f html -o tmp/rubocop/report.html
     - uses: actions/upload-artifact@v2
       with:
         name: rubocop-report
@@ -32,4 +32,4 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          rubocop --parallel | reviewdog -reporter=github-pr-review -f=rubocop
+          bundle exec rubocop --parallel | reviewdog -reporter=github-pr-review -f=rubocop

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6
+        ruby-version: 2.7
     - name: Install rubocop
       run: |
         gem install bundled_gems
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
       - name: Install rubocop
         run: |
           gem install bundled_gems

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,18 +9,13 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - name: Install rubocop
-      run: |
-        gem install bundled_gems
-        bgem install rubocop
-        bgem install rubocop-rails_config
+        bundler-cache: true
     - name: Run RuboCop
       run: rubocop --parallel -f progress -f html -o tmp/rubocop/report.html
     - uses: actions/upload-artifact@v2
       with:
         name: rubocop-report
         path: tmp/rubocop/report.html
-
   reviewdog:
     runs-on: ubuntu-latest
     steps:
@@ -32,11 +27,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - name: Install rubocop
-        run: |
-          gem install bundled_gems
-          bgem install rubocop
-          bgem install rubocop-rails_config
+          bundler-cache: true
       - name: Run rubocop & reviewdog
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- Use ruby/setup-ruby `bundler-cache: true` option
  -  > runs 'bundle install' and caches installed gems automatically
  - https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
- Bump actions package
  - toshimaru/auto-author-assign
  - paambaati/codeclimate-action
- Remove `skip ci` feature
  - [GitHub Actions: Skip pull request and push workflows with [skip ci] - GitHub Changelog](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)