### PR TITLE
Disable AJAX for form

### DIFF
--- a/app/views/shared/_tweet_form.html.erb
+++ b/app/views/shared/_tweet_form.html.erb
@@ -1,5 +1,5 @@
 <div class="tweet-box">
-  <%= form_with model: current_user.tweets.new do |form| %>
+  <%= form_with model: current_user.tweets.new, local: true do |form| %>
     <div class="field">
       <%= form.text_area :content, placeholder: "Compose new Tweet..." %>
     </div>


### PR DESCRIPTION
Follow up #1047

Creating tweet form doesn't work since it works with AJAX.

Disable AJAX for all forms.