### PR TITLE
Optimize docker-compose.yml part.2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 .git
+.bundle
 node_modules/
 vendor/bundle/
+log/*
+tmp/*

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: docker-compose build
+    - run: DOCKER_BUILDKIT=1 docker-compose build
     - run: docker-compose run web bin/webpack
     - run: docker-compose run web bundle exec rspec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,6 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: DOCKER_BUILDKIT=1 docker-compose build
+    - run: DOCKER_BUILDKIT=1 docker-compose build --parallel
     - run: docker-compose run web bin/webpack
     - run: docker-compose run web bundle exec rspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN apt update -qq && apt install -y nodejs chromium-driver yarn && apt clean &&
 RUN mkdir /app
 COPY Gemfile Gemfile.lock package.json yarn.lock /app/
 WORKDIR /app
-RUN bundle install
+RUN bundle install --jobs=2
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,5 @@ RUN apt update -qq && apt install -y nodejs chromium-driver yarn && apt clean &&
 RUN mkdir /app
 COPY Gemfile Gemfile.lock package.json yarn.lock /app/
 WORKDIR /app
-RUN gem install bundler
 RUN bundle install
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN apt update -qq && apt install -y nodejs chromium-driver yarn && apt clean &&
 RUN mkdir /app
 COPY Gemfile Gemfile.lock package.json yarn.lock /app/
 WORKDIR /app
+RUN yarn install
 COPY --from=bundle-installer /usr/local/bundle/ /usr/local/bundle/
 RUN bundle install
-RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN apt update -qq && apt install -y nodejs chromium-driver yarn && apt clean &&
 RUN mkdir /app
 COPY Gemfile Gemfile.lock package.json yarn.lock /app/
 WORKDIR /app
-RUN bundle install --jobs=2
+RUN bundle install --jobs=4
 RUN yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM ruby:2.7 AS bundle-installer
+
+WORKDIR /tmp
+COPY Gemfile Gemfile.lock /tmp/
+RUN bundle install --jobs=2
+
 FROM ruby:2.7
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
@@ -6,5 +12,6 @@ RUN apt update -qq && apt install -y nodejs chromium-driver yarn && apt clean &&
 RUN mkdir /app
 COPY Gemfile Gemfile.lock package.json yarn.lock /app/
 WORKDIR /app
-RUN bundle install --jobs=4
+COPY --from=bundle-installer /usr/local/bundle/ /usr/local/bundle/
+RUN bundle install
 RUN yarn install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   web:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && rails s -b '0.0.0.0'"
+    command: bin/rails s -b '0.0.0.0'
     volumes:
       - .:/app:cached
       - bundle:/usr/local/bundle:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     volumes:
       - .:/app:cached
       - bundle:/usr/local/bundle:cached
+      - node_modules:/app/node_modules:cached
       - /app/.git
       - /app/log
-      - /app/node_modules
       - /app/tmp
       - /app/vendor
       - /app/db/sqlite
@@ -16,3 +16,4 @@ services:
       - "3000:3000"
 volumes:
   bundle:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && rails s -b '0.0.0.0'"
     volumes:
       - .:/app:cached
+      - bundle:/usr/local/bundle:cached
       - /app/.git
       - /app/log
       - /app/node_modules
@@ -13,3 +14,5 @@ services:
       - /app/db/sqlite
     ports:
       - "3000:3000"
+volumes:
+  bundle:


### PR DESCRIPTION
follows #676

## Changes

- `DOCKER_BUILDKIT=1` to enable buildkit
  - [Build images with BuildKit | Docker Documentation](https://docs.docker.com/develop/develop-images/build_enhancements/)
  - [moby/buildkit: concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit](https://github.com/moby/buildkit)
- Add `--parallel` to docker-compose
- [Use multi-stage builds | Docker Documentation](https://docs.docker.com/develop/develop-images/multistage-build/)
- Use volume mount for bundler and node_modules.
  - [Use volumes | Docker Documentation](https://docs.docker.com/storage/volumes/)
  - [Compose file version 3 reference | Docker Documentation](https://docs.docker.com/compose/compose-file/compose-file-v3/#volume-configuration-reference)

> Compose by default uses the docker CLI to perform builds (also known as “native build”). By using the docker CLI, Compose can take advantage of features such as BuildKit, which are not supported by Compose itself. BuildKit is enabled by default on Docker Desktop, but requires the DOCKER_BUILDKIT=1 environment variable to be set on other platforms.

[docker-compose build | Docker Documentation](https://docs.docker.com/compose/reference/build/)

## Result

before: 5m 50s
after: 4m 10s
Result: 20% faster

![image](https://user-images.githubusercontent.com/803398/111557202-9607b680-87cf-11eb-8670-5e38d19a7341.png)
https://github.com/toshimaru/RailsTwitterClone/runs/2102538106

![image](https://user-images.githubusercontent.com/803398/111557373-dff09c80-87cf-11eb-9b94-b74d077fa43d.png)
https://github.com/toshimaru/RailsTwitterClone/runs/2104816490

![image](https://user-images.githubusercontent.com/803398/111558598-673f0f80-87d2-11eb-8255-84a7fd411f57.png)
https://github.com/toshimaru/RailsTwitterClone/pull/1052/checks?check_run_id=2135876474

## Next Step

Use cache (image cache, bundler cache, or any?)