### PR TITLE
Add permissions to auto-author-assign action

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -2,6 +2,9 @@ name: 'Auto Author Assign'
 on:
   pull_request_target:
     types: [opened, reopened]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   assign-author:
     runs-on: ubuntu-latest


### PR DESCRIPTION
ref. https://github.com/toshimaru/auto-author-assign#usage

### Error?

(Due to github actions incidents?)

```
Run toshimaru/auto-author-assign@v1.3.1
  Error: Resource not accessible by integration
```

https://github.com/toshimaru/RailsTwitterClone/pull/1142/checks?check_run_id=2593719488