### PR TITLE
Dependabot: Set `open-pull-requests-limit: 10`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  reviewers:
-  - toshimaru
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  reviewers:
-  - toshimaru
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  reviewers:
-  - toshimaru
-
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      - toshimaru
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      - toshimaru
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - toshimaru


### PR DESCRIPTION
ref. [Configuration options for dependency updates - GitHub Docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit)