### PR TITLE
Dependabot: Set dependency-type "all" for bundler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
     reviewers:
       - toshimaru
+    allow:
+      - dependency-type: "all"
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/"


### PR DESCRIPTION
ref. https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#allow