### PR TITLE
Drop Ruby 2.5

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,4 @@ inherit_gem:
     - config/rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Check out this repository and then,
 
 ```console
 $ bundle install
+$ rails webpacker:install
 $ bundle exec rails db:migrate
 $ bundle exec rails server
 ```


### PR DESCRIPTION
```
Ruby 2.5
status: eol
release date: 2017-12-25
EOL date: 2021-03-31
```

ref. https://www.ruby-lang.org/en/downloads/branches/