### PR TITLE
Fix Selenium deprecation message: options → capabilities

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ Capybara.register_driver :headless_chrome do |app|
     opts.args << "--disable-gpu"
     opts.args << "--no-sandbox"
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: browser_options)
 end
 
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Fix the following message:

```
WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for driver initialization is deprecated. Use :capabilities with an Array of value capabilities/options if necessary instead.
```