### PR TITLE
Update for Docker compose v2

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   web:
     build: .


### PR DESCRIPTION
- Rename: `docker-compose.yml` → `compose.yml`
- Remove `version` from compose.yml

## Reference

- [Docker Compose V2で変わったdocker-compose.ymlの書き方](https://zenn.dev/miroha/articles/whats-docker-compose-v2)