### PR TITLE
Change ActiveRecord migration version

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   web:
     build: .
-    command: bin/rails s -b '0.0.0.0'
+    command: bash -c "bundle && bin/rails s -b '0.0.0.0'"
     volumes:
       - .:/app:cached
       - bundle:/usr/local/bundle:cached

--- a/db/migrate/20210329000001_create_users.rb
+++ b/db/migrate/20210329000001_create_users.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUsers < ActiveRecord::Migration[6.0]
+class CreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|
       t.string :name, null: false

--- a/db/migrate/20210404000001_create_tweets.rb
+++ b/db/migrate/20210404000001_create_tweets.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateTweets < ActiveRecord::Migration[6.0]
+class CreateTweets < ActiveRecord::Migration[6.1]
   def change
     create_table :tweets do |t|
       t.string :content, null: false

--- a/db/migrate/20210404000002_create_join_table_relationships.rb
+++ b/db/migrate/20210404000002_create_join_table_relationships.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateJoinTableRelationships < ActiveRecord::Migration[6.0]
+class CreateJoinTableRelationships < ActiveRecord::Migration[6.1]
   def change
     create_join_table :followers, :followeds, table_name: :relationships do |t|
       t.index [:follower_id, :followed_id], unique: true

--- a/db/migrate/20220219155729_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20220219155729_create_active_storage_variant_records.active_storage.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This migration comes from active_storage (originally 20191206030411)
-class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
+class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.1]
   def change
     create_table :active_storage_variant_records do |t|
       t.belongs_to :blob, null: false, index: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2022_02_19_155729) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end


### PR DESCRIPTION
To fix the following error:

```
Column `xxx_id` on table `yyy` does not match column `id` on `zzz`, which has type `bigint(20)`. To resolve this issue, change the type of the `xxx_id` column on `yyy` to be :bigint. (For example `t.bigint :xxx_id`).
Original message: Mysql2::Error: Cannot add foreign key constraint
```

- [Rails 7でテーブルカラムの型不一致による外部キー追加エラーが発生した場合の解決方法 - Qiita](https://qiita.com/hypermkt/items/fc2a4bc4b1e03c44d6d3)