### PR TITLE
Bump CircleCI Orbs to the latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.2.4
-  node: circleci/node@5.0.0
-  ruby: circleci/ruby@1.3.0
+  browser-tools: circleci/browser-tools@1.4.0
+  node: circleci/node@5.0.3
+  ruby: circleci/ruby@2.0.0
 
 executors:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
           clean-bundle: true
   rspec:
     executor: default
-    parallelism: 2
     steps:
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
           clean-bundle: true
   rspec:
     executor: default
+    parallelism: 2
     steps:
       - checkout
       - ruby/install-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
           command: |
             sudo apt update
             sudo apt install libsqlite3-dev
-      - ruby/install-deps
+      - ruby/install-deps:
+          clean-bundle: true
   rspec:
     executor: default
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
       - image: cimg/ruby:3.1-browsers
         environment:
           RAILS_ENV: test
+    resource_class: small
 
 jobs:
   setup:
@@ -19,9 +20,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: |
-            sudo apt update
-            sudo apt install libsqlite3-dev
+          command: sudo apt install libsqlite3-dev
       - ruby/install-deps:
           clean-bundle: true
   rspec:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - ruby/rubocop-check
+      - ruby/rubocop-check:
+          parallel: true
 
 workflows:
   build:


### PR DESCRIPTION
```yml
browser-tools: circleci/browser-tools@1.4.0
node: circleci/node@5.0.3
ruby: circleci/ruby@2.0.0
```

- Use `resource_class: small`
- Add `clean-bundle: true` for install-deps
- Add `parallel: true` for rubocop-check