### PR TITLE
wip: Use cimg/ruby:3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/ruby:3.1-browsers
+      - image: cimg/ruby:3.1
         environment:
           RAILS_ENV: test
     resource_class: small
@@ -28,6 +28,9 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
+      - node/install:
+          install-yarn: true
+          node-version: '16'
       - node/install-packages:
           pkg-manager: yarn
       - browser-tools/install-chrome


### PR DESCRIPTION
Install node v16 in order to fix the following error:

```
bin/webpack
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/home/circleci/project/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/circleci/project/node_modules/webpack/lib/NormalModule.js:417:16)
    at /home/circleci/project/node_modules/webpack/lib/NormalModule.js:452:10
    at /home/circleci/project/node_modules/webpack/lib/NormalModule.js:323:13
    at /home/circleci/project/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /home/circleci/project/node_modules/loader-runner/lib/LoaderRunner.js:233:18
    at context.callback (/home/circleci/project/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/circleci/project/node_modules/babel-loader/lib/index.js:59:103 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.12.1

Exited with code exit status 1
```