### PR TITLE
Add `bundle-install` command to commonize `ruby/install-deps` / Use `cimg/ruby:3.1-browsers`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - bundle-install
   rspec:
     executor: default
+    resource_class: medium
     steps:
       - checkout
       - bundle-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,13 @@ executors:
           RAILS_ENV: test
     resource_class: small
 
+commands:
+  bundle-install:
+    steps:
+      - ruby/install-deps:
+          clean-bundle: true
+          key: gems-v2
+
 jobs:
   setup:
     executor: default
@@ -21,13 +28,12 @@ jobs:
       - run:
           name: Install System Dependencies
           command: sudo apt install libsqlite3-dev
-      - ruby/install-deps:
-          clean-bundle: true
+      - bundle-install
   rspec:
     executor: default
     steps:
       - checkout
-      - ruby/install-deps
+      - bundle-install
       - node/install:
           install-yarn: true
           node-version: '16'
@@ -48,7 +54,7 @@ jobs:
     executor: default
     steps:
       - checkout
-      - ruby/install-deps
+      - bundle-install
       - ruby/rubocop-check:
           parallel: true
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/ruby:3.1
+      - image: cimg/ruby:3.1-browsers
         environment:
           RAILS_ENV: test
     resource_class: small


### PR DESCRIPTION
Related PR: #1684

Update file to fix the error on CircleCI:

```
bin/rails db:schema:load --trace
rails aborted!
LoadError: libssl.so.1.1: cannot open shared object file: No such file or directory - /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/puma_http11.so
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.7/lib/active_support/dependencies.rb:332:in `block in require'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.7/lib/active_support/dependencies.rb:299:in `load_dependency'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/activesupport-6.1.7/lib/active_support/dependencies.rb:332:in `require'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma.rb:14:in `<main>'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/home/circleci/.rubygems/gems/bundler-2.3.7/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
/home/circleci/.rubygems/gems/bundler-2.3.7/lib/bundler/runtime.rb:55:in `each'
/home/circleci/.rubygems/gems/bundler-2.3.7/lib/bundler/runtime.rb:55:in `block in require'
/home/circleci/.rubygems/gems/bundler-2.3.7/lib/bundler/runtime.rb:44:in `each'
/home/circleci/.rubygems/gems/bundler-2.3.7/lib/bundler/runtime.rb:44:in `require'
/home/circleci/.rubygems/gems/bundler-2.3.7/lib/bundler.rb:176:in `require'
/home/circleci/project/config/application.rb:9:in `<main>'
/home/circleci/project/Rakefile:6:in `require_relative'
/home/circleci/project/Rakefile:6:in `<main>'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_module.rb:29:in `load_rakefile'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:710:in `raw_load_rakefile'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:104:in `block in load_rakefile'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/application.rb:103:in `load_rakefile'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/railties-6.1.7/lib/rails/commands/rake/rake_command.rb:20:in `block in perform'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/lib/rake/rake_module.rb:59:in `with_application'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/railties-6.1.7/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/railties-6.1.7/lib/rails/command.rb:50:in `invoke'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/railties-6.1.7/lib/rails/commands.rb:18:in `<main>'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/bootsnap-1.15.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
bin/rails:4:in `<main>'

Exited with code exit status 1
```