### PR TITLE
Bump Ruby from 3.1 to 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/ruby:3.1-browsers
+      - image: cimg/ruby:3.2-browsers
         environment:
           RAILS_ENV: test
     resource_class: small

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: 3.2
         bundler-cache: true
     - name: Setup webpacker
       run: |

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['3.1']
+        ruby: [3.2]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.7, '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1', '3.2']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: 3.2
     - name: Install Code Scanning integration
       run: bundle add code-scanning-rubocop --skip-install
     - name: Install dependencies

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -3,6 +3,7 @@ name: RuboCop
 on: [pull_request]
 
 jobs:
+
   rubocop:
     runs-on: ubuntu-latest
     steps:
@@ -10,7 +11,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: 3.2
         bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop --parallel -f progress -f html -o tmp/rubocop/report.html
@@ -18,6 +19,7 @@ jobs:
       with:
         name: rubocop-report
         path: tmp/rubocop/report.html
+
   reviewdog:
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +28,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: 3.2
         bundler-cache: true
     - name: Run rubocop & reviewdog
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:3.1 AS bundle-installer
+FROM ruby:3.2 AS bundle-installer
 
 WORKDIR /tmp
 COPY Gemfile Gemfile.lock /tmp/
 RUN bundle install --jobs=2
 
-FROM ruby:3.1
+FROM ruby:3.2
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
Bump Ruby version from 3.1 to 3.2 for:

- CircleCI
- GitHub Action
- Dockerfile