### PR TITLE
Use node v16 / Bump @rails/ujs from 6.1.7 to 6.1.7-2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,9 @@ jobs:
       with:
         ruby-version: 3.2
         bundler-cache: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - name: Setup webpacker
       run: |
         yarn install --frozen-lockfile

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,6 +20,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - name: Setup webpacker
       run: |
         yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "license": "UNLICENSED",
   "dependencies": {
-    "@rails/ujs": "^6.1.7",
+    "@rails/ujs": "^6.1.7-2",
     "@rails/webpacker": "5.4.4",
     "bootstrap": "^5.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,7 +1159,7 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@rails/ujs@^6.1.7":
+"@rails/ujs@^6.1.7-2":
   version "6.1.7"
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.1.7.tgz#b09dc5b2105dd267e8374c47e4490240451dc7f6"
   integrity sha512-0e7WQ4LE/+LEfW2zfAw9ppsB6A8RmxbdAUPAF++UT80epY+7emuQDkKXmaK0a9lp6An50RvzezI0cIQjp1A58w==


### PR DESCRIPTION
## Error

```
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/webpack/lib/NormalModule.js:417:[16](https://github.com/toshimaru/RailsTwitterClone/actions/runs/4214063919/jobs/7314259405#step:4:17))
    at /home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/webpack/lib/NormalModule.js:452:10
    at /home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/webpack/lib/NormalModule.js:323:13
    at /home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/loader-runner/lib/LoaderRunner.js:367:11
    at /home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/loader-runner/lib/LoaderRunner.js:233:[18](https://github.com/toshimaru/RailsTwitterClone/actions/runs/4214063919/jobs/7314259405#step:4:19)
    at context.callback (/home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
    at /home/runner/work/RailsTwitterClone/RailsTwitterClone/node_modules/babel-loader/lib/index.js:59:103 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.14.1
Error: Process completed with exit code 1.
```