### PR TITLE
Set groups for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 10
+    groups:
+      debug-gem:
+        patterns:
+          - "debug"
+          - "irb"
+          - "reline"
+      rubocop:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
[Grouped version updates for Dependabot public beta | GitHub Changelog](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)