### PR TITLE
Bump CircleCI Orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.0
-  node: circleci/node@5.0.3
-  ruby: circleci/ruby@2.0.0
+  browser-tools: circleci/browser-tools@1.4.4
+  node: circleci/node@5.1.0
+  ruby: circleci/ruby@2.1.0
 
 executors:
   default:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,10 @@ jobs:
           node-version: '16'
       - node/install-packages:
           pkg-manager: yarn
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          # TODO: Remove following line when fixed https://github.com/CircleCI-Public/browser-tools-orb/issues/90
+          chrome-version: 116.0.5845.96
+          replace-existing: true
       - browser-tools/install-chromedriver
       - run: bin/rails db:schema:load --trace
       - run: bin/webpack


### PR DESCRIPTION
## Changes

- Bump CircleCI Orbs
  - circleci/browser-tools@1.4.0 -> 1.4.4
  - circleci/node@5.0.3 -> 5.1.0
  - circleci/ruby@2.0.0 -> 2.1.0
- ci: Use chrome v116.0.5845.96 to fix CI

## Reference

- [Circleci/browser-tools failing on ChromeDriver 116.x - Build Environment / Running Tests - CircleCI Discuss](https://discuss.circleci.com/t/circleci-browser-tools-failing-on-chromedriver-116-x/49119/2)