### PR TITLE
fix: Remove ` NODE_OPTIONS=--openssl-legacy-provide`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
-  node: circleci/node@5.1.0
-  ruby: circleci/ruby@2.1.0
+  browser-tools: circleci/browser-tools@1.4.8
+  node: circleci/node@5.2.0
+  ruby: circleci/ruby@2.1.2
 
 executors:
   default:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN mkdir /app
 COPY Gemfile Gemfile.lock package.json yarn.lock /app/
 
 WORKDIR /app
-ENV NODE_OPTIONS=--openssl-legacy-provider
 RUN yarn install
 COPY --from=bundle-installer /usr/local/bundle/ /usr/local/bundle/
 RUN bundle install


### PR DESCRIPTION
Fix the following error that occurs during the `Dockerfile` build:

```
> [stage-1  8/10] RUN yarn install:
0.067 node: --openssl-legacy-provider is not allowed in NODE_OPTIONS
```

## Related PR

- #1787

## Related Commit

- https://github.com/toshimaru/RailsTwitterClone/pull/1904/commits/3443d95a0f8470446ea584d95e9e03ed0596d1b0