### PR TITLE
deps: Drop Ruby 2.7 / Support Ruby 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,7 @@ jobs:
     steps:
       - checkout
       - bundle-install
-      - ruby/rubocop-check:
-          parallel: true
+      - ruby/rubocop-check
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/ruby:3.2-browsers
+      - image: cimg/ruby:3.3-browsers
         environment:
           RAILS_ENV: test
     resource_class: small
@@ -18,7 +18,7 @@ commands:
     steps:
       - ruby/install-deps:
           clean-bundle: true
-          key: gems-v2
+          key: gems-v3
 
 jobs:
   setup:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ruby:3.2 AS bundle-installer
+FROM ruby:3.3 AS bundle-installer
 
 WORKDIR /tmp
 COPY Gemfile Gemfile.lock /tmp/
 RUN bundle install --jobs=2
 
-FROM ruby:3.2
+FROM ruby:3.3
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
- Nokogiri v1.16 requires Ruby v3.0+, so drop Ruby 2.7 support (ref #2192)
- Complete Ruby v3.3 support (`Dockerfile` and `.circleci/config.yml`)