### PR TITLE
deps: Ignore zeitwerk 2.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     allow:
       - dependency-type: "all"
     open-pull-requests-limit: 15
+    ignore:
+      - dependency-name: "zeitwerk"
+        versions:
+          - "2.7.x"
     groups:
       debug-gem:
         patterns:


### PR DESCRIPTION
Since it requires Ruby 3.2+.

related. #2366