### PR TITLE
deps: Lock concurrent-ruby v1.3.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       # nokogiri v1.18.0+ requires Ruby 3.0+
       - dependency-name: "nokogiri"
         versions: [">= 1.18.0"]
+      - dependency-name: "concurrent-ruby"
+        versions: [">= 1.3.5"]
     groups:
       debug-gem:
         patterns:


### PR DESCRIPTION
## Related PR

- #2483

## Error

```
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning " > bootstrap@5.3.3" has unmet peer dependency "@popperjs/core@^2.11.8".
warning " > webpack-dev-server@3.11.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
warning "webpack-dev-server > webpack-dev-middleware@3.7.3" has unmet peer dependency "webpack@^4.0.0 || ^5.0.0".
[4/4] Building fresh packages...
Done in 12.[6](https://github.com/toshimaru/RailsTwitterClone/actions/runs/13698950228/job/38307769674#step:5:7)5s.
/home/runner/work/RailsTwitterClone/RailsTwitterClone/vendor/bundle/ruby/3.3.0/gems/activesupport-6.1.[7](https://github.com/toshimaru/RailsTwitterClone/actions/runs/13698950228/job/38307769674#step:5:8).10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
    ^^^^^^
	from /home/runner/work/RailsTwitterClone/RailsTwitterClone/vendor/bundle/ruby/3.3.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:[9](https://github.com/toshimaru/RailsTwitterClone/actions/runs/13698950228/job/38307769674#step:5:10):in `<module:ActiveSupport>'
```