### PR TITLE
Remove `git_source(:github)` from `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source "https://rubygems.org"
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem "rails", "~> 6.1.7.10"
 


### PR DESCRIPTION
bundler itself has `github:` shorthand
see. https://bundler.io/guides/git.html