### PR TITLE
refactor: Define `ruby:3.3` as a base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM ruby:3.3 AS bundle-installer
+FROM ruby:3.3 AS base
+WORKDIR /app
 
-WORKDIR /tmp
-COPY Gemfile Gemfile.lock /tmp/
-RUN bundle install --jobs=2
+FROM base AS bundle-installer
 
-FROM ruby:3.3
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs=4
+
+FROM base
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list
 RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt update -qq && apt install -y nodejs chromium-driver yarn && apt clean && rm -rf /var/lib/apt/lists/*
-RUN mkdir /app
-COPY Gemfile Gemfile.lock package.json yarn.lock /app/
+COPY Gemfile Gemfile.lock package.json yarn.lock ./
 
-WORKDIR /app
 RUN yarn install
 COPY --from=bundle-installer /usr/local/bundle/ /usr/local/bundle/
 RUN bundle install


### PR DESCRIPTION
## TODOs

- [ ] Use `-slim` image
- [ ] Bump to ruby:3.4 image