### PR TITLE
fix: selenium capabilities → options

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ Capybara.register_driver :headless_chrome do |app|
     opts.args << "--disable-gpu"
     opts.args << "--no-sandbox"
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
 end
 
 Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
## Warning

```
WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options argument with an instance of Selenium::WebDriver::Chrome::Driver instead.
```