### PR TITLE
deps: Enable dependabot for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,12 @@ updates:
       interval: daily
     reviewers:
       - toshimaru
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - toshimaru
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
ref. [Dependabot options reference - GitHub Docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference)