### PR TITLE
Create `User#session_token` to prevent session hijacking

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -3,6 +3,8 @@
 module SessionsHelper
   def log_in(user)
     session[:user_id] = user.id
+    # Guard against session replay attacks.
+    session[:session_token] = user.session_token
   end
 
   def logged_in?
@@ -17,7 +19,10 @@ module SessionsHelper
 
   def current_user
     if (user_id = session[:user_id])
-      @current_user ||= User.find_by(id: user_id)
+      user ||= User.find_by(id: user_id)
+      if user && session[:session_token] == user.session_token
+        @current_user = user
+      end
     elsif (user_id = cookies.encrypted[:user_id])
       user = User.find_by(id: user_id)
       if user&.authenticated?(cookies[:remember_token])

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -19,7 +19,7 @@ module SessionsHelper
 
   def current_user
     if (user_id = session[:user_id])
-      user ||= User.find_by(id: user_id)
+      user = User.find_by(id: user_id)
       if user && session[:session_token] == user.session_token
         @current_user = user
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,9 +50,11 @@ class User < ApplicationRecord
     following.delete(other_user)
   end
 
+  # Remembers a user in the database for use in persistent sessions.
   def remember
     self.remember_token = self.class.new_token
     update_attribute(:remember_digest, self.class.digest(remember_token))
+    remember_digest
   end
 
   def authenticated?(remember_token)
@@ -63,6 +65,12 @@ class User < ApplicationRecord
 
   def forget
     update_attribute(:remember_digest, nil)
+  end
+
+  # Returns a session token to prevent session hijacking.
+  # We reuse the remember digest for convenience.
+  def session_token
+    remember_digest || remember
   end
 
   class << self

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,4 +194,14 @@ RSpec.describe User, type: :model do
       is_expected.not_to include(unfollowed_tweet)
     end
   end
+
+  describe "#remember" do
+    subject { user.remember }
+    it { is_expected.to eq user.remember_digest }
+  end
+
+  describe "#session_token" do
+    subject { user.session_token }
+    it { is_expected.to eq user.remember_digest }
+  end
 end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "/home", type: :request do
         log_in_as(user)
         get home_url
       }
-      it { expect(response).to be_ok }
+      it { expect(response).to have_http_status(:ok) }
     end
 
     context "without login" do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "/sessions", type: :request do
 
   describe "GET /new" do
     before { get login_url }
-    it { expect(response).to be_ok }
+    it { expect(response).to have_http_status(:ok) }
   end
 
   describe "POST /create" do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -45,5 +45,19 @@ RSpec.describe "/sessions", type: :request do
       before { delete logout_path }
       it { expect(response).to redirect_to(root_url) }
     end
+
+    context "Session Replay" do
+      before { log_in_as(user) }
+      it "prevents session replay attack" do
+        session_cookie = cookies["_rails_twitter_clone_session"]
+        get home_path
+        expect(response).to have_http_status(:ok)
+
+        delete logout_path
+        cookies["_rails_twitter_clone_session"] = session_cookie
+        get home_path
+        expect(response).to have_http_status(:redirect)
+      end
+    end
   end
 end

--- a/spec/requests/tweets_spec.rb
+++ b/spec/requests/tweets_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "/tweets", type: :request do
   describe "GET /index" do
     before { get tweets_path }
-    it { expect(response).to be_ok }
+    it { expect(response).to have_http_status(:ok) }
   end
 
   describe "POST /create" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe "/users", type: :request do
 
   describe "GET /index" do
     before { get users_path }
-    it { expect(response).to be_ok }
+    it { expect(response).to have_http_status(:ok) }
   end
 
   describe "GET /show" do
     before { get user_path(user.slug) }
-    it { expect(response).to be_ok }
+    it { expect(response).to have_http_status(:ok) }
   end
 
   describe "GET /new" do
     before { get signup_path }
-    it { expect(response).to be_ok }
+    it { expect(response).to have_http_status(:ok) }
   end
 
   describe "POST /create" do
@@ -32,7 +32,7 @@ RSpec.describe "/users", type: :request do
     describe "User already exists" do
       it "doesn't create a new user" do
         post users_path, params: { user: FactoryBot.attributes_for(:user, email: user.email) }
-        expect(response).to be_ok
+        expect(response).to have_http_status(:ok)
       end
     end
   end
@@ -69,7 +69,7 @@ RSpec.describe "/users", type: :request do
 
       describe "showing my edit page" do
         before { get edit_user_path(user) }
-        it { expect(response).to be_ok }
+        it { expect(response).to have_http_status(:ok) }
       end
 
       describe "showing another user's edit page" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "/users", type: :request do
 
   describe "DELETE /destroy" do
     context "without login" do
-      it "doen't delete a user" do
+      it "doesn't delete a user" do
         delete user_path(user.slug)
         expect(response).to redirect_to(login_path)
       end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "/", type: :request do
   context "without login" do
     describe "GET /index" do
       before { get root_url }
-      it { expect(response).to be_ok }
+      it { expect(response).to have_http_status(:ok) }
     end
   end
 


### PR DESCRIPTION
## Changes

- feat: Guard against session reply attack
  - Create `User#session_token` to prevent session hijacking
- Add test cases
  - test: `User#remember` & `User#session_token`
  - test: Test session replay attack scenario
- others
  - fix: Fix typo
  - chore: Use `have_http_status(:ok)` instead of `be_ok`

## Related article

- [Binary Solo | Avoiding session replay attacks in Rails](https://binarysolo.blog/avoiding-session-replay-attacks-in-rails/)
- [Japanese][Railsでセッションリプレイ攻撃を防ぐ方法（翻訳）｜TechRacho by BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2023_06_02/130443)