### PR TITLE
Add `User.admin` flag / feat: Admin user can delete any user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,8 @@
 class UsersController < ApplicationController
   before_action :set_user,       only: [:show, :edit, :update, :destroy, :following, :followers]
   before_action :logged_in_user, only: [:edit, :update, :destroy]
-  before_action :correct_user,   only: [:edit, :update, :destroy]
+  before_action :correct_user,   only: [:edit, :update]
+  before_action :admin_user,     only: :destroy
 
   def index
     @users = User.all
@@ -73,5 +74,10 @@ class UsersController < ApplicationController
       unless current_user?(@user)
         redirect_to(root_path)
       end
+    end
+
+    # Confirms an admin user.
+    def admin_user
+      redirect_to(root_url) unless current_user.admin?
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   before_action :set_user,       only: [:show, :edit, :update, :destroy, :following, :followers]
   before_action :logged_in_user, only: [:edit, :update, :destroy]
   before_action :correct_user,   only: [:edit, :update]
-  before_action :admin_user,     only: :destroy
+  before_action :admin_or_correct_user, only: :destroy
 
   def index
     @users = User.all
@@ -76,8 +76,7 @@ class UsersController < ApplicationController
       end
     end
 
-    # Confirms an admin user.
-    def admin_user
-      redirect_to(root_url) unless current_user.admin?
+    def admin_or_correct_user
+      redirect_to(root_url) unless current_user.admin? || current_user?(@user)
     end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -19,6 +19,7 @@ module SessionsHelper
 
   def current_user
     if (user_id = session[:user_id])
+      # TODO: memoize current_user result
       user = User.find_by(id: user_id)
       if user && session[:session_token] == user.session_token
         @current_user = user

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -9,6 +9,7 @@
   <% if @tweets.any? %>
     <div class="timeline">
       <ol class="tweets">
+        <%# TODO: collection rendering %>
         <%= render @tweets %>
         <div class="my-4">
           <%= will_paginate @tweets, renderer: WillPaginate::ActionView::BootstrapLinkRenderer %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,4 +1,12 @@
 <li class="tweet clearfix">
   <%= gravatar_for user %>
   <%= link_to user.name, user %>
+  <% if current_user&.admin? && !current_user?(user) %>
+    <div class="tweet-footer">
+      <div class="tweet-actions">
+        <%= link_to "delete", user, method: :delete,
+                                    data: { confirm: "You sure?" } %>
+      </div>
+    </div>
+  <% end %>
 </li>

--- a/db/migrate/20250403011618_add_admin_to_users.rb
+++ b/db/migrate/20250403011618_add_admin_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdminToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_19_155729) do
+ActiveRecord::Schema.define(version: 2025_04_03_011618) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2022_02_19_155729) do
     t.string "remember_digest"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["remember_digest"], name: "index_users_on_remember_digest"
     t.index ["slug"], name: "index_users_on_slug", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# Create a main sample user.
+User.create!(name:  "Example User",
+             slug:  "example-user",
+             email: "example@railstutorial.org",
+             password:              "foobar",
+             password_confirmation: "foobar",
+             admin: true)
+
+# Generate a bunch of additional users.
+99.times do |n|
+  name  = Faker::Name.name
+  email = "example-#{n + 1}@railstutorial.org"
+  password = "password"
+  User.create!(name:  name,
+               slug:  name.parameterize,
+               email: email,
+               password:              password,
+               password_confirmation: password)
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     sequence(:email) { |n| "#{n}-#{Faker::Internet.email}" }
     password { "FactoryBot" }
     password_confirmation { "FactoryBot" }
+
+    trait :admin do
+      admin { true }
+    end
   end
 end

--- a/spec/system/authentication_system_spec.rb
+++ b/spec/system/authentication_system_spec.rb
@@ -51,30 +51,5 @@ RSpec.describe "Authentication", type: :system do
         it { is_expected.to have_link("Sign in") }
       end
     end
-
-    context "without login" do
-      let(:user) { FactoryBot.create(:user) }
-
-      describe "in the Users Controller" do
-        describe "visit the following page" do
-          before { visit following_user_path(user) }
-          it { is_expected.to have_title("Following") }
-        end
-
-        describe "visit the followers page" do
-          before { visit followers_user_path(user) }
-          it { is_expected.to have_title("Followers") }
-        end
-
-        describe "visiting the user index" do
-          before { visit users_path }
-          it { is_expected.to have_title("Users") }
-
-          describe "screenshot", js: true do
-            it { page.save_screenshot "users.png" }
-          end
-        end
-      end
-    end
   end
 end

--- a/spec/system/users/index_spec.rb
+++ b/spec/system/users/index_spec.rb
@@ -6,16 +6,44 @@ RSpec.describe "User Index", type: :system do
   subject { page }
 
   describe "Showing all users" do
-    before do
-      FactoryBot.create_list(:user, 3)
-      visit users_path
+    let!(:users) { FactoryBot.create_list(:user, 3) }
+
+    context "without login" do
+      before do
+        visit users_path
+      end
+
+      it "lists users" do
+        is_expected.to have_title("Users")
+        is_expected.not_to have_content("delete")
+        users.each do |user|
+          is_expected.to have_link(user.name, href: user_path(user))
+        end
+      end
+
+      describe "screenshot", js: true do
+        it { page.save_screenshot "users.png" }
+      end
     end
 
-    it "lists users" do
-      is_expected.to have_title("Users")
-      is_expected.to have_content("Users")
-      User.all.each do |user|
-        expect(page).to have_selector("li", text: user.name)
+    context "login" do
+      let(:admin_user) { FactoryBot.create(:user, :admin) }
+
+      before do
+        log_in_as(admin_user)
+        visit users_path
+      end
+
+      it "lists users with delete link" do
+        is_expected.to have_title("Users")
+        users.each do |user|
+          is_expected.to have_link(user.name, href: user_path(user))
+          is_expected.to have_link("delete", href: user_path(user))
+        end
+      end
+
+      describe "screenshot", js: true do
+        it { page.save_screenshot "users-admin.png" }
       end
     end
   end

--- a/spec/system/users/index_spec.rb
+++ b/spec/system/users/index_spec.rb
@@ -27,23 +27,37 @@ RSpec.describe "User Index", type: :system do
     end
 
     context "login" do
-      let(:admin_user) { FactoryBot.create(:user, :admin) }
-
       before do
-        log_in_as(admin_user)
+        log_in_as(login_user)
         visit users_path
       end
 
-      it "lists users with delete link" do
-        is_expected.to have_title("Users")
-        users.each do |user|
-          is_expected.to have_link(user.name, href: user_path(user))
-          is_expected.to have_link("delete", href: user_path(user))
+      context "as non-admin" do
+        let(:login_user) { FactoryBot.create(:user) }
+
+        it "lists users with delete link" do
+          is_expected.to have_title("Users")
+          is_expected.not_to have_content("delete")
+          users.each do |user|
+            is_expected.to have_link(user.name, href: user_path(user))
+          end
         end
       end
 
-      describe "screenshot", js: true do
-        it { page.save_screenshot "users-admin.png" }
+      context "as admin" do
+        let(:login_user) { FactoryBot.create(:user, :admin) }
+
+        it "lists users with delete link" do
+          is_expected.to have_title("Users")
+          users.each do |user|
+            is_expected.to have_link(user.name, href: user_path(user))
+            is_expected.to have_link("delete", href: user_path(user))
+          end
+        end
+
+        describe "screenshot", js: true do
+          it { page.save_screenshot "users-admin.png" }
+        end
       end
     end
   end


### PR DESCRIPTION
Admin user can delete any user.

<img width="768" alt="image" src="https://github.com/user-attachments/assets/a0be4985-2b60-4249-8c28-1b31167fc0ee" />

## DB Migration

```console
$ rails generate migration add_admin_to_users admin:boolean
```

## Changes

- feat: Admin user can delete any user
  - Create `AddAdminToUsers` migration
- Create `db/seeds.rb`
  - Migrating from `lib/tasks/sample_data.rake` to `db/seeds.rb`
- fix: Change from `admin_user` to `admin_or_correct_user`
- Test changes
  - test: Remove duplicated tests
  - test: Admin user can see the delete link
  - test: login as non-admin user
- chore: Leave TODOs