### PR TITLE
fix: Fix relationship dependent destroy

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,11 +7,11 @@ class User < ApplicationRecord
   has_many :active_relationships, class_name:  "Relationship",
                                   foreign_key: "follower_id",
                                   inverse_of: :follower,
-                                  dependent: :destroy
+                                  dependent: :delete_all
   has_many :passive_relationships, class_name: "Relationship",
                                    foreign_key: "followed_id",
                                    inverse_of: :followed,
-                                   dependent: :destroy
+                                   dependent: :delete_all
   has_many :following, through: :active_relationships,  source: :followed
   has_many :followers, through: :passive_relationships, source: :follower
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,30 +76,33 @@ RSpec.describe User, type: :model do
   end
 
   describe "associations" do
-    subject(:user) { users(:fixture_user_1) }
+    let(:user) { users(:fixture_user_1) }
     let(:other_user) { users(:fixture_user_2) }
 
     describe ".followers" do
+      subject { other_user.followers }
       before { FactoryBot.create(:relationship, follower: user, followed: other_user) }
-      it { expect(other_user.followers).to include(user) }
+      it { is_expected.to include(user) }
     end
 
     describe ".following" do
+      subject { user.following }
       before { FactoryBot.create(:relationship, follower: user, followed: other_user) }
-      it { expect(user.following).to include(other_user) }
+      it { is_expected.to include(other_user) }
     end
 
     describe ".tweets" do
+      subject { user.tweets }
       let!(:older_tweet) { FactoryBot.create(:tweet, user: user, created_at: 1.day.ago) }
       let!(:newer_tweet) { FactoryBot.create(:tweet, user: user, created_at: 1.hour.ago) }
 
       it "has the right tweets in the right order" do
-        expect(user.tweets).to eq [newer_tweet, older_tweet]
+        is_expected.to eq [newer_tweet, older_tweet]
       end
 
       it "destroys associated tweets" do
         user.destroy!
-        expect(user.tweets).to eq []
+        is_expected.to eq []
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -79,16 +79,26 @@ RSpec.describe User, type: :model do
     let(:user) { users(:fixture_user_1) }
     let(:other_user) { users(:fixture_user_2) }
 
-    describe ".followers" do
-      subject { other_user.followers }
-      before { FactoryBot.create(:relationship, follower: user, followed: other_user) }
-      it { is_expected.to include(user) }
-    end
-
     describe ".following" do
       subject { user.following }
       before { FactoryBot.create(:relationship, follower: user, followed: other_user) }
       it { is_expected.to include(other_user) }
+
+      it "destroys associated following" do
+        user.destroy!
+        is_expected.to eq []
+      end
+    end
+
+    describe ".followers" do
+      subject { other_user.followers }
+      before { FactoryBot.create(:relationship, follower: user, followed: other_user) }
+      it { is_expected.to include(user) }
+
+      it "destroys associated followers" do
+        user.destroy!
+        is_expected.to eq []
+      end
     end
 
     describe ".tweets" do


### PR DESCRIPTION
## Error

```
 Failure/Error: user.destroy!

 ActiveRecord::StatementInvalid:
   SQLite3::SQLException: no such column: relationships.
 # ./spec/models/user_spec.rb:99:in `block (4 levels) in <top (required)>'
 # ------------------
 # --- Caused by: ---
 # SQLite3::SQLException:
 #   no such column: relationships.
 #   ./spec/models/user_spec.rb:99:in `block (4 levels) in <top (required)>'
```

## Changes

- refactor: Use subject block effectively
- test: destroy following/followers dependent `User.destroy`
- fix: Fix dependent deletion for User.relationships
