### PR TITLE
docs: Add Qlty badges

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,4 +3,4 @@ inherit_gem:
     - config/rails.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![RSpec](https://github.com/toshimaru/RailsTwitterClone/actions/workflows/rspec.yml/badge.svg?branch=main)](https://github.com/toshimaru/RailsTwitterClone/actions/workflows/rspec.yml)
-[![Qlty](https://github.com/toshimaru/RailsTwitterClone/actions/workflows/qlty.yml/badge.svg)](https://github.com/toshimaru/RailsTwitterClone/actions/workflows/qlty.yml)
+[![Maintainability](https://qlty.sh/gh/toshimaru/projects/RailsTwitterClone/maintainability.svg)](https://qlty.sh/gh/toshimaru/projects/RailsTwitterClone)
+[![Code Coverage](https://qlty.sh/gh/toshimaru/projects/RailsTwitterClone/coverage.svg)](https://qlty.sh/gh/toshimaru/projects/RailsTwitterClone)
 [![CircleCI](https://circleci.com/gh/toshimaru/RailsTwitterClone.svg?style=svg)](https://circleci.com/gh/toshimaru/RailsTwitterClone)
 ![Supported Ruby Version](https://img.shields.io/badge/Ruby-v3.3-green)
 ![Supported Rails Version](https://img.shields.io/badge/Rails-v6.1-green)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ This implementation is based on [Ruby on Rails Tutorial](https://www.railstutori
 - v3.2
 - v3.1
 - v3.0
-- v2.7
 
 ## Setup
 


### PR DESCRIPTION
This pull request includes updates to the Ruby version configuration and enhancements to the `README.md` file to improve project documentation and compatibility.

### Ruby version update:
* [`.rubocop.yml`](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL6-R6): Updated `TargetRubyVersion` from 2.7 to 3.0 to align with newer Ruby standards.

### Documentation enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R3): Replaced the "Qlty" badge with "Maintainability" and added a "Code Coverage" badge for improved project insights.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23): Removed references to Ruby version 2.7 from the list of supported versions to reflect the updated Ruby version compatibility.